### PR TITLE
Issue 8: Stubs cannot raise exceptions fix

### DIFF
--- a/ludibrio/specification/unit/stub.dt
+++ b/ludibrio/specification/unit/stub.dt
@@ -51,7 +51,6 @@ Stubs are test doubles programmed to provide inputs to and outputs from collabor
     >>> greetings
     Greetings
 
-
 4. Should support both method and property configuration:
     >>> with greetings as greetings:
     ...     greetings.excuse_me() >> 'Com licença'
@@ -78,4 +77,12 @@ Stubs are test doubles programmed to provide inputs to and outputs from collabor
     Ola, Gustavo e Diego
     >>> print greetings.hello('Gustavo')
     Ola, Gustavo
+
+5. Stubs should be able to raise exceptions 
+    >>> with Stub() as stubException:
+    ...     stubException.hello() >> KeyError('KEY ERROR')
+    >>> stubException.hello()
+    Traceback (most recent call last):
+    ...
+    KeyError: 'KEY ERROR'
 

--- a/ludibrio/stub.py
+++ b/ludibrio/stub.py
@@ -55,14 +55,17 @@ class Stub(_TestDouble):
         self.__expectation__.append(expectation)
 
     def __rshift__(self, response):
-            self.__expectation__[-1][3] = response
+        self.__expectation__[-1][3] = response
     __lshift__ = __rshift__
 
     def _expectation_value(self, attr, args=[], kargs={}):
         for position, (attr_expectation, args_expectation, kargs_expectation, response) in enumerate(self.__expectation__):
             if (attr_expectation, args_expectation, kargs_expectation) == (attr, args, kargs):
                 self._to_the_end(position)
-                return response
+                if isinstance(response, Exception):
+                    raise response 
+                else:
+                    return response
         if self._has_proxy():
             return self._proxy(attr, args, kargs)
         self._attribute_expectation(attr, args, kargs)


### PR DESCRIPTION
Summary:
Corrected issue in stubs not being able to raise exceptions as per issue...#8 (https://github.com/nsigustavo/ludibrio/issues/8) and added unit test to verify functionality

Solution Summary:
-Added logic in stub.py to raise response if it was an exception. Previously it always returned.
-Added unit test to verify this functionality.

Here are the doctest results with no failures:

son@ubuntu:~/projects/ludibrio/ludibrio$ doctest
/home/jason/projects/ludibrio/ludibrio/specification/unit/mock.dt
TestResults(failed=0, attempted=29)

/home/jason/projects/ludibrio/ludibrio/specification/unit/mock_msg_error.dt
TestResults(failed=0, attempted=10)

/home/jason/projects/ludibrio/ludibrio/specification/unit/stub_proxy.dt
TestResults(failed=0, attempted=5)

/home/jason/projects/ludibrio/ludibrio/specification/unit/bug_getattr.dt
TestResults(failed=0, attempted=6)

/home/jason/projects/ludibrio/ludibrio/specification/unit/spy.dt
TestResults(failed=0, attempted=18)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/kind_of.dt
TestResults(failed=0, attempted=7)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/equal_to_ignoring_case.dt
TestResults(failed=0, attempted=9)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/ended_with.dt
TestResults(failed=0, attempted=4)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/less_than.dt
TestResults(failed=0, attempted=7)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/like.dt
TestResults(failed=0, attempted=4)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/custom.dt
TestResults(failed=0, attempted=5)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/specialarguments.dt
TestResults(failed=0, attempted=14)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/in_any_order.dt
TestResults(failed=0, attempted=8)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/started_with.dt
TestResults(failed=0, attempted=4)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/greater_than_or_equal_to.dt
TestResults(failed=0, attempted=8)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/into.dt
TestResults(failed=0, attempted=5)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/less_than_or_equal_to.dt
TestResults(failed=0, attempted=8)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/equal_to.dt
TestResults(failed=0, attempted=6)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/contains.dt
TestResults(failed=0, attempted=4)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/instance_of.dt
TestResults(failed=0, attempted=7)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/greater_than.dt
TestResults(failed=0, attempted=7)

/home/jason/projects/ludibrio/ludibrio/specification/unit/specialarguments/any_of.dt
TestResults(failed=0, attempted=5)

/home/jason/projects/ludibrio/ludibrio/specification/unit/stub.dt
TestResults(failed=0, attempted=28)

/home/jason/projects/ludibrio/ludibrio/specification/unit/dependencyinjection.dt
TestResults(failed=0, attempted=8)

/home/jason/projects/ludibrio/ludibrio/specification/unit/mock_unordered.dt
TestResults(failed=0, attempted=6)

/home/jason/projects/ludibrio/ludibrio/specification/unit/mock_and_stub_dependencyinjection.dt
TestResults(failed=0, attempted=8)

/home/jason/projects/ludibrio/ludibrio/specification/unit/stub_msg_error.dt
TestResults(failed=0, attempted=6)

/home/jason/projects/ludibrio/ludibrio/specification/unit/dummy.dt
TestResults(failed=0, attempted=36)

/home/jason/projects/ludibrio/ludibrio/specification/unit/dependencyinjection_importforadocontexto.dt
TestResults(failed=0, attempted=5)

/home/jason/projects/ludibrio/ludibrio/specification/functional/testdouble.dt
TestResults(failed=0, attempted=13)
